### PR TITLE
unlist tmp to match dist2land's output with Windows

### DIFF
--- a/R/dist2land.R
+++ b/R/dist2land.R
@@ -151,6 +151,7 @@ dist2land <- function(data, lon = NULL, lat = NULL, shapefile = NULL, proj.in = 
         cl <- parallel::makeCluster(cores, rscript_args = c("--no-init-file", "--no-site-file", "--no-environ"))
         out <- parallel::parLapply(cl, 1:length(x), function(i) suppressWarnings(rgeos::gDistance(x[i], land)/1000))
         parallel::stopCluster(cl)
+        tmp <- unlist(out)
       }
       else {
         tmp <- unlist(parallel::mclapply(1:length(x), function(i) {


### PR DESCRIPTION
On Windows, results are stored in `out` variable, but never unlisted in a `tmp` variable, resulting into a column filled with `'lat'` and `'lon'` values because `tmp` is also created at the beginning of the function with these two values. So I just added `tmp <- unlist(out)` and that did the trick! 