### PR TITLE
⚡ Optimize dist2land distance calculation

### DIFF
--- a/R/dist2land.R
+++ b/R/dist2land.R
@@ -138,7 +138,11 @@ dist2land <- function(data, lon = NULL, lat = NULL, shapefile = "DecimalDegree",
   } else { ## Distance
     
     if(verbose) message("Calculating distances...")
-    tmp <- apply(sf::st_distance(x, land), 1, min)/1e3 # km
+
+    if(!inherits(land, "sf")) land <- sf::st_as_sf(land)
+
+    nearest <- sf::st_nearest_feature(x, land)
+    tmp <- as.numeric(sf::st_distance(x, land[nearest,], by_element = TRUE))/1e3 # km
     
     if(sf::st_is_longlat(x)) {
       if(verbose) message("Returning great circle spherical distances from land as kilometers.")


### PR DESCRIPTION
This PR optimizes the `dist2land` function in `R/dist2land.R`.

**Optimization:**
-   Replaced `apply(sf::st_distance(x, land), 1, min)` with:
    ```r
    nearest <- sf::st_nearest_feature(x, land)
    tmp <- as.numeric(sf::st_distance(x, land[nearest,], by_element = TRUE))/1e3
    ```
-   This reduces the complexity from calculating distances between all points and all polygons ($O(N \times M)$) to finding the nearest polygon ($O(N \log M)$) and calculating distance only to that polygon ($O(N)$).

**Robustness:**
-   Added `if(!inherits(land, "sf")) land <- sf::st_as_sf(land)` to ensure `land` is an `sf` object. This handles `sp` objects (legacy) and `sfc` objects (geometry only), enabling correct row subsetting `land[nearest,]`.

**Verification:**
-   Verified code logic by inspection.
-   Ensured output format (numeric kilometers) is preserved.

---
*PR created automatically by Jules for task [1050677878041999741](https://jules.google.com/task/1050677878041999741) started by @MikkoVihtakari*