### PR TITLE
Add tests for basemap, qmap, get_depth and dist2land

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Description: Allows plotting data on bathymetric maps using 'ggplot2'. Plotting
   when needed. 
 Depends: R (>= 3.5.0), ggplot2 (>= 3.4.0)
 Imports: sf, stars, methods, utils, smoothr, units
-Suggests: ggspatial, cowplot, knitr, rmarkdown, scales, ggnewscale
+Suggests: ggspatial, cowplot, knitr, rmarkdown, scales, ggnewscale, testthat
 License: GPL-3
 Encoding: UTF-8
 RoxygenNote: 7.3.3

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(ggOceanMaps)
+
+test_check("ggOceanMaps")

--- a/tests/testthat/test-basemap.R
+++ b/tests/testthat/test-basemap.R
@@ -1,0 +1,26 @@
+test_that("basemap works with integer limits", {
+  p <- basemap(limits = 60)
+  expect_s3_class(p, "ggplot")
+})
+
+test_that("basemap works with vector limits", {
+  p <- basemap(limits = c(-20, 20, 40, 59))
+  expect_s3_class(p, "ggplot")
+})
+
+test_that("basemap works with data limits", {
+  dt <- data.frame(lon = c(-150, 150), lat = c(60, 90))
+  p <- basemap(data = dt)
+  expect_s3_class(p, "ggplot")
+})
+
+test_that("basemap works with bathymetry", {
+  p <- basemap(limits = c(-60, -50, 60, 70), bathymetry = TRUE)
+  expect_s3_class(p, "ggplot")
+})
+
+test_that("basemap works with rotate", {
+  dt <- data.frame(lon = c(-160, 160, 160, -160), lat = c(80, 80, 60, 60))
+  p <- basemap(data = dt, rotate = TRUE)
+  expect_s3_class(p, "ggplot")
+})

--- a/tests/testthat/test-dist2land.R
+++ b/tests/testthat/test-dist2land.R
@@ -1,0 +1,22 @@
+test_that("dist2land works with data frame", {
+  dt <- data.frame(lon = seq(-20, 80, length.out = 41), lat = 50:90)
+  res <- dist2land(dt, verbose = FALSE)
+  expect_true(is.data.frame(res))
+  expect_true("ldist" %in% names(res))
+})
+
+test_that("dist2land works with binary option", {
+  dt <- data.frame(lon = c(0, 10), lat = c(60, 70))
+  res <- dist2land(dt, binary = TRUE, verbose = FALSE)
+  expect_true(is.data.frame(res))
+  # binary = TRUE returns ldist column as logical?
+  # Manual says: "The distances are kilometers if binary = FALSE, otherwise logical (TRUE = the position is in the ocean, FALSE = the position is on land)."
+  expect_type(res$ldist, "logical")
+})
+
+test_that("dist2land returns vector when bind = FALSE", {
+  dt <- data.frame(lon = c(0, 10), lat = c(60, 70))
+  res <- dist2land(dt, bind = FALSE, verbose = FALSE)
+  expect_true(is.vector(res))
+  expect_length(res, 2)
+})

--- a/tests/testthat/test-get_depth.R
+++ b/tests/testthat/test-get_depth.R
@@ -1,0 +1,15 @@
+test_that("get_depth works with data frame", {
+  dt <- data.frame(lon = seq(-20, 80, length.out = 41), lat = 50:90)
+  # bathy.style defaults to "raster_continuous" which requires download.
+  # We use "raster_binned_blues" (rbb) which is shipped with the package.
+  res <- get_depth(dt, bathy.style = "rbb", verbose = FALSE)
+  expect_true(is.data.frame(res))
+  expect_true("depth" %in% names(res))
+})
+
+test_that("get_depth returns vector when bind = FALSE", {
+  dt <- data.frame(lon = c(0, 10), lat = c(60, 70))
+  res <- get_depth(dt, bathy.style = "rbb", bind = FALSE, verbose = FALSE)
+  expect_true(is.vector(res))
+  expect_length(res, 2)
+})

--- a/tests/testthat/test-qmap.R
+++ b/tests/testthat/test-qmap.R
@@ -1,0 +1,23 @@
+test_that("qmap works with basic data frame", {
+  dt <- data.frame(lon = c(-100, -80, -60), lat = c(10, 25, 40), var = c("a", "a", "b"))
+  p <- qmap(dt)
+  expect_s3_class(p, "ggplot")
+})
+
+test_that("qmap works with color aesthetic", {
+  dt <- data.frame(lon = c(-100, -80, -60), lat = c(10, 25, 40), var = c("a", "a", "b"))
+  p <- qmap(dt, color = I("blue"))
+  expect_s3_class(p, "ggplot")
+})
+
+test_that("qmap works with mapped color", {
+  dt <- data.frame(lon = c(-100, -80, -60), lat = c(10, 25, 40), var = c("a", "a", "b"))
+  p <- qmap(dt, color = var)
+  expect_s3_class(p, "ggplot")
+})
+
+test_that("qmap works with rotation", {
+  dt <- data.frame(lon = c(-80, -80, -50, -50), lat = c(65, 80, 80, 65))
+  p <- qmap(dt, rotate = TRUE)
+  expect_s3_class(p, "ggplot")
+})


### PR DESCRIPTION
Added tests for `basemap`, `qmap`, `get_depth`, and `dist2land` functions using `testthat`. The tests cover basic usage and various options as described in the documentation. `testthat` dependency was added to `DESCRIPTION`.

---
*PR created automatically by Jules for task [14760673102076204502](https://jules.google.com/task/14760673102076204502) started by @MikkoVihtakari*